### PR TITLE
feat: add PR guard to prevent accidental PRs to upstream (danny-avila/LibreChat)

### DIFF
--- a/docs/aainc/pr-guard.md
+++ b/docs/aainc/pr-guard.md
@@ -30,6 +30,17 @@ bash utils/aainc/setup-pr-guard.sh
 2. `git config remote.pushDefault origin` — push 先を origin (aainc) に固定
 3. フォーク元を指す remote が存在する場合、その push URL を無効化
 
+### npm install 時の自動適用
+
+セットアップスクリプトの実行忘れ対策として、`npm install` 実行時に同等のガード設定が
+`postinstall` フック（`utils/aainc/postinstall.js`）で自動適用される。
+
+- 適用内容は `setup-pr-guard.sh` と同等（`gh repo set-default` / `remote.pushDefault` /
+  フォーク元 remote の push 無効化）
+- CI 環境・git repo でない環境（tarball 展開 / Docker ビルド等）では何もせず skip する
+- gh 不在・未認証・origin 不一致などの異常時も **install は失敗させず**、警告表示に留める。
+  警告が出た場合は原因を解消のうえ `bash utils/aainc/setup-pr-guard.sh` を手動実行すること
+
 ## 運用ルール
 
 ### 1. upstream remote を追加しない

--- a/docs/aainc/pr-guard.md
+++ b/docs/aainc/pr-guard.md
@@ -1,0 +1,84 @@
+# aainc/LibreChat PR ガード運用ガイド
+
+本リポジトリは [danny-avila/LibreChat](https://github.com/danny-avila/LibreChat) の fork であり、
+社内カスタマイズを主目的とする。**PR は常に aainc/LibreChat 内（base リポジトリ: aainc）に向ける。**
+
+このドキュメントは、誤ってフォーク元 (upstream) に PR を出してしまう事故を防ぐための
+ローカル側ガードと運用ルールをまとめたものである。
+
+## なぜ事故が起きるのか
+
+- fork の clone で `gh pr create` を実行すると、gh はフォーク元 (danny-avila/LibreChat) を
+  PR の base リポジトリ候補として扱う。`gh repo set-default` 未設定の場合、対話プロンプトの
+  既定値や非対話実行時の解決先がフォーク元に向くことがある。
+- `gh repo clone aainc/LibreChat` で clone すると、フォーク元が `upstream` remote として
+  **自動追加**される。これにより gh の base リポジトリ解決がフォーク元に引っ張られる。
+- GitHub 側に「fork の PR 先既定を変える」設定は存在しないため、ガードはローカル / clone 側で
+  多層に敷く必要がある。
+
+## 初回セットアップ（clone 直後に必ず実行）
+
+```bash
+git clone https://github.com/aainc/LibreChat.git
+cd LibreChat
+bash utils/aainc/setup-pr-guard.sh
+```
+
+`setup-pr-guard.sh` は以下を一括で行う:
+
+1. `gh repo set-default aainc/LibreChat` — gh の PR / issue 操作の既定リポジトリを aainc に固定
+2. `git config remote.pushDefault origin` — push 先を origin (aainc) に固定
+3. フォーク元を指す remote が存在する場合、その push URL を無効化
+
+## 運用ルール
+
+### 1. upstream remote を追加しない
+
+通常の開発でフォーク元 remote は不要。**`git remote add upstream ...` をしないこと。**
+upstream 同期（フォーク元の取り込み）が必要な場合は、担当者が同期作業時のみ一時的に追加し、
+作業後に `git remote remove upstream` で削除する。残す場合は `setup-pr-guard.sh` を再実行して
+push を無効化しておく。
+
+### 2. PR 作成は wrapper script を使う
+
+```bash
+bash utils/aainc/create-pr.sh --title "..." --body "..."
+```
+
+wrapper は `gh pr create --repo aainc/LibreChat --base main` を強制する。
+aainc 内の別ブランチに向けたい場合のみ `--base <branch>` を追加で渡す（後勝ちで上書きされる）。
+
+### 3. 素の gh pr create を使う場合は --repo を必ず明示
+
+wrapper を使えない事情がある場合でも、必ず以下の形で実行する:
+
+```bash
+gh pr create --repo aainc/LibreChat --base main ...
+```
+
+`--repo` を省略した `gh pr create` は禁止。CI / 自動化スクリプトから PR を作成する場合も同様に
+`--repo aainc/LibreChat` を明示すること。
+
+### 4. Web UI から PR を作成する場合
+
+GitHub の compare 画面では base リポジトリのドロップダウンが
+`danny-avila/LibreChat` に向いていないか**必ず確認**する。
+URL で直接指定するのが安全:
+
+```
+https://github.com/aainc/LibreChat/compare/main...<branch>
+```
+
+## PR 作成前チェックリスト
+
+- [ ] `gh repo set-default --view` が `aainc/LibreChat` を返す
+- [ ] `git remote -v` にフォーク元への push 可能な remote がない
+- [ ] PR 作成コマンドに `--repo aainc/LibreChat` が明示されている（または wrapper を使用）
+- [ ] 作成後、PR の URL が `github.com/aainc/LibreChat/pull/...` であることを確認
+
+## 誤ってフォーク元に PR を出してしまった場合
+
+1. 即座に該当 PR をクローズする（マージ権限がなくても作成者はクローズできる）
+2. PR 本文・コミットに社内情報が含まれていないか確認する。含まれていた場合は
+   リーダーに報告する（フォーク元のリポジトリ管理者への削除依頼が必要になることがある）
+3. `bash utils/aainc/setup-pr-guard.sh` を再実行してガード設定を復旧する

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "node utils/aainc/postinstall.js",
     "update": "node config/update.js",
     "add-balance": "node config/add-balance.js",
     "set-balance": "node config/set-balance.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "node utils/aainc/postinstall.js",
+    "postinstall": "node -e \"try{require('./utils/aainc/postinstall.js')}catch(e){if(e.code!=='MODULE_NOT_FOUND')throw e}\"",
     "update": "node config/update.js",
     "add-balance": "node config/add-balance.js",
     "set-balance": "node config/set-balance.js",

--- a/utils/aainc/create-pr.sh
+++ b/utils/aainc/create-pr.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# aainc/LibreChat 向け PR 作成 wrapper
+#
+# PR 先を常に aainc/LibreChat (base: main) に明示して gh pr create を実行する。
+# フォーク元 (danny-avila/LibreChat) へ誤って PR を出す事故を構造的に防ぐ。
+#
+# 使い方:
+#   bash utils/aainc/create-pr.sh [gh pr create の追加オプション...]
+#
+# 例:
+#   bash utils/aainc/create-pr.sh --title "feat: ..." --body "..."
+#   bash utils/aainc/create-pr.sh --fill
+#   bash utils/aainc/create-pr.sh --base release/v0.8 --title "..."  # base 上書きも可
+#
+# 詳細は docs/aainc/pr-guard.md を参照。
+
+set -euo pipefail
+
+AAINC_REPO="aainc/LibreChat"
+
+# --repo が引数で渡されていても aainc 以外は拒否する
+for arg in "$@"; do
+  case "$arg" in
+    --repo|--repo=*|-R)
+      if [[ "$arg" != "--repo=${AAINC_REPO}" ]]; then
+        echo "ERROR: --repo の上書きは禁止です。PR は常に ${AAINC_REPO} に向けます。" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+# --base は後勝ちのため、追加引数での上書き（aainc 内の別ブランチ向け）は許容される
+exec gh pr create --repo "$AAINC_REPO" --base main "$@"

--- a/utils/aainc/postinstall.js
+++ b/utils/aainc/postinstall.js
@@ -1,0 +1,102 @@
+/**
+ * aainc/LibreChat PR ガード postinstall フック
+ *
+ * npm install 時に utils/aainc/setup-pr-guard.sh 相当のガード設定を自動適用する
+ * （セットアップスクリプトの実行忘れ対策）。
+ *
+ * 重要: このスクリプトは install を絶対に失敗させない。
+ * - git repo でない環境（tarball 展開 / Docker ビルド等）→ silent skip
+ * - CI 環境 → silent skip
+ * - gh 不在 / 未認証、origin 不一致 → 警告のみで正常終了
+ *
+ * 詳細は docs/aainc/pr-guard.md を参照。
+ */
+const { execSync } = require('child_process');
+
+const AAINC_REPO = 'aainc/LibreChat';
+const UPSTREAM_PATTERN = 'danny-avila/LibreChat';
+const TAG = '[aainc-pr-guard]';
+
+function tryRun(cmd) {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  // CI では不要（PR 作成は人間のローカル環境からのみ行う想定）
+  if (process.env.CI || process.env.NODE_ENV === 'CI') {
+    return;
+  }
+
+  // git repo でなければ skip（tarball 展開 / Docker ビルド等）
+  if (tryRun('git rev-parse --is-inside-work-tree') !== 'true') {
+    return;
+  }
+
+  const originUrl = tryRun('git remote get-url origin');
+  if (!originUrl || !originUrl.includes(AAINC_REPO)) {
+    if (originUrl && originUrl.includes(UPSTREAM_PATTERN)) {
+      console.warn(
+        `${TAG} warning: origin がフォーク元 (${UPSTREAM_PATTERN}) を指しています。` +
+          ` aainc fork で作業する場合は git remote set-url origin https://github.com/${AAINC_REPO}.git を実行してください。`,
+      );
+    }
+    return;
+  }
+
+  // 1. push 先を origin に固定
+  if (tryRun('git config remote.pushDefault origin') !== null) {
+    console.log(`${TAG} git config remote.pushDefault origin を設定しました`);
+  }
+
+  // 2. gh の既定リポジトリを aainc fork に固定
+  if (tryRun('gh --version') !== null) {
+    if (tryRun(`gh repo set-default ${AAINC_REPO}`) !== null) {
+      console.log(`${TAG} gh repo set-default ${AAINC_REPO} を設定しました`);
+    } else {
+      console.warn(
+        `${TAG} warning: gh repo set-default に失敗しました（gh 未認証の可能性）。` +
+          ` 後で bash utils/aainc/setup-pr-guard.sh を実行してください。`,
+      );
+    }
+  } else {
+    console.warn(
+      `${TAG} warning: gh コマンドが見つかりません。` +
+        ` インストール後に bash utils/aainc/setup-pr-guard.sh を実行してください。`,
+    );
+  }
+
+  // 3. フォーク元を指す remote の push を無効化
+  const remotes = (tryRun('git remote') || '').split('\n').filter(Boolean);
+  for (const remote of remotes) {
+    if (remote === 'origin') {
+      continue;
+    }
+    const url = tryRun(`git remote get-url ${remote}`);
+    if (url && url.includes(UPSTREAM_PATTERN) && !url.startsWith('DISABLED')) {
+      const pushUrl = tryRun(`git remote get-url --push ${remote}`);
+      if (pushUrl && pushUrl.startsWith('DISABLED')) {
+        continue; // 設定済み
+      }
+      if (tryRun(`git remote set-url --push ${remote} DISABLED_DO_NOT_PUSH_TO_UPSTREAM`) !== null) {
+        console.warn(
+          `${TAG} warning: remote '${remote}' はフォーク元を指しているため push を無効化しました。` +
+            ` docs/aainc/pr-guard.md を参照。`,
+        );
+      }
+    }
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  // どんな失敗でも install は止めない
+  console.warn(`${TAG} skip: ${err.message}`);
+}
+process.exitCode = 0;

--- a/utils/aainc/setup-pr-guard.sh
+++ b/utils/aainc/setup-pr-guard.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# aainc/LibreChat PR ガードセットアップ
+#
+# clone 直後に 1 回実行する。フォーク元 (danny-avila/LibreChat) へ誤って
+# PR や push をしてしまう事故を防ぐためのローカル設定を一括で行う。
+#
+# 使い方:
+#   bash utils/aainc/setup-pr-guard.sh
+#
+# 詳細は docs/aainc/pr-guard.md を参照。
+
+set -euo pipefail
+
+AAINC_REPO="aainc/LibreChat"
+UPSTREAM_PATTERN="danny-avila/LibreChat"
+
+cd "$(git rev-parse --show-toplevel)"
+
+# 0. origin が aainc fork を指しているか確認
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+if [[ "$origin_url" != *"${AAINC_REPO}"* ]]; then
+  echo "ERROR: origin が ${AAINC_REPO} を指していません: ${origin_url:-（未設定）}" >&2
+  echo "       git remote set-url origin https://github.com/${AAINC_REPO}.git を実行してください。" >&2
+  exit 1
+fi
+
+# 1. gh の既定リポジトリを aainc fork に固定
+#    （fork clone では gh pr create の PR 先既定がフォーク元 upstream に向くため）
+if command -v gh >/dev/null 2>&1; then
+  gh repo set-default "$AAINC_REPO"
+  echo "ok: gh repo set-default ${AAINC_REPO}"
+else
+  echo "warning: gh コマンドが見つかりません。インストール後に再実行してください。" >&2
+fi
+
+# 2. push 先を origin に固定
+git config remote.pushDefault origin
+echo "ok: git config remote.pushDefault origin"
+
+# 3. フォーク元を指す remote が存在する場合は push を無効化
+#    （gh repo clone はフォーク元を upstream remote として自動追加するため）
+for remote in $(git remote); do
+  [[ "$remote" == "origin" ]] && continue
+  url="$(git remote get-url "$remote" 2>/dev/null || true)"
+  if [[ "$url" == *"$UPSTREAM_PATTERN"* ]]; then
+    git remote set-url --push "$remote" DISABLED_DO_NOT_PUSH_TO_UPSTREAM
+    echo "warning: remote '${remote}' はフォーク元 (${UPSTREAM_PATTERN}) を指しています。push を無効化しました。"
+    echo "         upstream 同期作業以外でこの remote は不要です。docs/aainc/pr-guard.md を参照。"
+  fi
+done
+
+echo
+echo "セットアップ完了。PR 作成は utils/aainc/create-pr.sh を使用してください。"


### PR DESCRIPTION
## Summary

This fork (aainc/LibreChat) is primarily for internal customization. Since `gh pr create` on a fork clone resolves the upstream parent (danny-avila/LibreChat) as the default PR base, there is a standing risk of accidentally opening internal PRs against the upstream repository. This PR adds a multi-layer local guard to prevent that.

## Changes

- **`docs/aainc/pr-guard.md`** — Operations guide: why the accident happens, setup steps, operating rules (no upstream remote, always explicit `--repo`, Web UI checklist), pre-PR checklist, and incident response if a PR is accidentally opened upstream.
- **`utils/aainc/setup-pr-guard.sh`** — One-shot setup after clone: pins `gh repo set-default aainc/LibreChat`, sets `git config remote.pushDefault origin`, disables push URLs of any remote pointing at the upstream parent, and fails fast if `origin` is not the aainc fork.
- **`utils/aainc/create-pr.sh`** — PR creation wrapper that forces `gh pr create --repo aainc/LibreChat --base main` and rejects any attempt to override `--repo` to another repository.
- **`utils/aainc/postinstall.js` + `package.json`** — Applies the same guard automatically on `npm install`, so the guard does not depend on developers remembering to run the setup script. Never fails the install: silently skips in CI / non-git environments (Docker builds, tarball extraction) and only warns when `gh` is missing/unauthenticated or `origin` mismatches.

## Verification

- Ran `setup-pr-guard.sh` in a clone: `gh repo set-default` pinned, `remote.pushDefault` set.
- `create-pr.sh` rejects `--repo` overrides targeting other repositories.
- `postinstall.js` exits 0 in CI-simulated and non-git environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)