### PR TITLE
feat: sort MCP servers/tools deterministically for stable prompt cache keys

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -452,7 +452,9 @@ const loadTools = async ({
   const failedMCPServers = new Set();
   const safeUser = createSafeUser(options.req?.user);
 
-  for (const [serverName, toolConfigs] of Object.entries(requestedMCPTools)) {
+  /** Sorted by server name for deterministic ordering, which keeps prompt cache keys stable across requests */
+  const sortedMCPEntries = Object.entries(requestedMCPTools).sort(([a], [b]) => a.localeCompare(b));
+  for (const [serverName, toolConfigs] of sortedMCPEntries) {
     index++;
     /** @type {LCAvailableTools} */
     let availableTools;

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -141,6 +141,15 @@ const getAuthFields = (toolKey) => {
 };
 
 /**
+ * Sorts MCP tool instances by tool name for deterministic ordering,
+ * which keeps prompt cache keys stable across requests
+ * @param {Tool[]} mcpTools
+ * @returns {Tool[]}
+ */
+const sortMCPToolsByName = (mcpTools) =>
+  mcpTools.sort((a, b) => (a?.name ?? '').localeCompare(b?.name ?? ''));
+
+/**
  *
  * @param {object} params
  * @param {string} params.user
@@ -452,8 +461,16 @@ const loadTools = async ({
   const failedMCPServers = new Set();
   const safeUser = createSafeUser(options.req?.user);
 
-  /** Sorted by server name for deterministic ordering, which keeps prompt cache keys stable across requests */
-  const sortedMCPEntries = Object.entries(requestedMCPTools).sort(([a], [b]) => a.localeCompare(b));
+  /**
+   * Sorted by server name, with each server's tool configs sorted by tool key, for
+   * deterministic ordering, which keeps prompt cache keys stable across requests
+   */
+  const sortedMCPEntries = Object.entries(requestedMCPTools)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([serverName, toolConfigs]) => [
+      serverName,
+      [...toolConfigs].sort((a, b) => (a.toolKey ?? '').localeCompare(b.toolKey ?? '')),
+    ]);
   for (const [serverName, toolConfigs] of sortedMCPEntries) {
     index++;
     /** @type {LCAvailableTools} */
@@ -507,7 +524,7 @@ const loadTools = async ({
               });
 
         if (Array.isArray(mcpTool)) {
-          loadedTools.push(...mcpTool);
+          loadedTools.push(...sortMCPToolsByName(mcpTool));
         } else if (mcpTool) {
           loadedTools.push(mcpTool);
         } else {
@@ -521,7 +538,11 @@ const loadTools = async ({
       }
     }
   }
-  loadedTools.push(...(await Promise.all(mcpToolPromises)).flatMap((plugin) => plugin || []));
+  loadedTools.push(
+    ...(await Promise.all(mcpToolPromises)).flatMap((plugin) =>
+      Array.isArray(plugin) ? sortMCPToolsByName(plugin) : plugin || [],
+    ),
+  );
   return { loadedTools, toolContextMap, dynamicToolContextMap, primedCodeFiles };
 };
 

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -30,7 +30,24 @@ jest.mock('~/server/services/Config', () => ({
   }),
 }));
 
+const mockCreateMCPTools = jest.fn();
+
+jest.mock('~/server/services/MCP', () => ({
+  createMCPTool: jest.fn(),
+  createMCPTools: mockCreateMCPTools,
+  createMCPPermissionContext: jest.fn(),
+  resolveConfigServers: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetServerConfig = jest.fn();
+
+jest.mock('~/config', () => ({
+  ...jest.requireActual('~/config'),
+  getMCPServersRegistry: jest.fn(() => ({ getServerConfig: mockGetServerConfig })),
+}));
+
 const { Calculator } = require('@librechat/agents');
+const { Constants } = require('librechat-data-provider');
 
 const { User } = require('~/db/models');
 const PluginService = require('~/server/services/PluginService');
@@ -281,6 +298,28 @@ describe('Tool Handlers', () => {
       const structuredTool = await toolFunctions['stable-diffusion']();
       expect(structuredTool).toBeInstanceOf(StructuredSD);
       delete process.env.SD_WEBUI_URL;
+    });
+
+    it('should initialize MCP servers in deterministic name order', async () => {
+      mockGetServerConfig.mockImplementation((serverName) =>
+        Promise.resolve({ type: 'stdio', command: 'node', args: [serverName] }),
+      );
+      mockCreateMCPTools.mockResolvedValue([]);
+
+      const tools = ['zebra', 'alpha', 'mango'].map(
+        (serverName) => `${Constants.mcp_all}${Constants.mcp_delimiter}${serverName}`,
+      );
+
+      await loadTools({
+        user: fakeUser._id,
+        tools,
+        options: {
+          mcpPermissionContext: { canUseServers: jest.fn().mockResolvedValue(true) },
+        },
+      });
+
+      const initializedOrder = mockCreateMCPTools.mock.calls.map(([params]) => params.serverName);
+      expect(initializedOrder).toEqual(['alpha', 'mango', 'zebra']);
     });
   });
 });

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -17,6 +17,7 @@ jest.mock('~/server/services/Config', () => ({
     filteredTools: [],
     includedTools: [],
   }),
+  getMCPServerTools: jest.fn().mockResolvedValue({}),
   getCachedTools: jest.fn().mockResolvedValue({
     // Default cached tools for tests
     dalle: {
@@ -30,10 +31,11 @@ jest.mock('~/server/services/Config', () => ({
   }),
 }));
 
+const mockCreateMCPTool = jest.fn();
 const mockCreateMCPTools = jest.fn();
 
 jest.mock('~/server/services/MCP', () => ({
-  createMCPTool: jest.fn(),
+  createMCPTool: mockCreateMCPTool,
   createMCPTools: mockCreateMCPTools,
   createMCPPermissionContext: jest.fn(),
   resolveConfigServers: jest.fn().mockResolvedValue(undefined),
@@ -320,6 +322,54 @@ describe('Tool Handlers', () => {
 
       const initializedOrder = mockCreateMCPTools.mock.calls.map(([params]) => params.serverName);
       expect(initializedOrder).toEqual(['alpha', 'mango', 'zebra']);
+    });
+
+    it('should initialize tools within an MCP server in deterministic name order', async () => {
+      mockGetServerConfig.mockImplementation((serverName) =>
+        Promise.resolve({ type: 'stdio', command: 'node', args: [serverName] }),
+      );
+      mockCreateMCPTool.mockImplementation(({ toolKey }) => Promise.resolve({ name: toolKey }));
+
+      const tools = ['zebra', 'alpha', 'mango'].map(
+        (toolName) => `${toolName}${Constants.mcp_delimiter}serverA`,
+      );
+
+      const { loadedTools } = await loadTools({
+        user: fakeUser._id,
+        tools,
+        options: {
+          mcpPermissionContext: { canUseServers: jest.fn().mockResolvedValue(true) },
+        },
+      });
+
+      const expectedOrder = ['alpha', 'mango', 'zebra'].map(
+        (toolName) => `${toolName}${Constants.mcp_delimiter}serverA`,
+      );
+      expect(mockCreateMCPTool.mock.calls.map(([params]) => params.toolKey)).toEqual(expectedOrder);
+      expect(loadedTools.map((tool) => tool.name)).toEqual(expectedOrder);
+    });
+
+    it('should sort tools returned by an MCP server in deterministic name order', async () => {
+      mockGetServerConfig.mockImplementation((serverName) =>
+        Promise.resolve({ type: 'stdio', command: 'node', args: [serverName] }),
+      );
+      mockCreateMCPTools.mockResolvedValue([
+        { name: `zebra${Constants.mcp_delimiter}serverA` },
+        { name: `alpha${Constants.mcp_delimiter}serverA` },
+      ]);
+
+      const { loadedTools } = await loadTools({
+        user: fakeUser._id,
+        tools: [`${Constants.mcp_all}${Constants.mcp_delimiter}serverA`],
+        options: {
+          mcpPermissionContext: { canUseServers: jest.fn().mockResolvedValue(true) },
+        },
+      });
+
+      expect(loadedTools.map((tool) => tool.name)).toEqual([
+        `alpha${Constants.mcp_delimiter}serverA`,
+        `zebra${Constants.mcp_delimiter}serverA`,
+      ]);
     });
   });
 });

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -270,8 +270,10 @@ export class MCPManager extends UserConnectionManager {
       return '';
     }
 
-    // Format instructions for context injection
+    // Format instructions for context injection (sorted by server name for deterministic
+    // ordering, which keeps prompt cache keys stable across requests)
     const formattedInstructions = Object.entries(instructionsToInclude)
+      .sort(([a], [b]) => a.localeCompare(b))
       .map(([serverName, instructions]) => {
         return `## ${serverName} MCP Server Instructions
 

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -298,6 +298,73 @@ describe('MCPManager', () => {
       expect(result).not.toContain('database');
     });
 
+    it('should sort server instructions by server name for deterministic ordering', async () => {
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
+        zebra: {
+          type: 'stdio',
+          command: 'node',
+          args: ['zebra.js'],
+          serverInstructions: 'Zebra instructions',
+        },
+        alpha: {
+          type: 'stdio',
+          command: 'node',
+          args: ['alpha.js'],
+          serverInstructions: 'Alpha instructions',
+        },
+        mango: {
+          type: 'stdio',
+          command: 'node',
+          args: ['mango.js'],
+          serverInstructions: 'Mango instructions',
+        },
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const result = await manager.formatInstructionsForContext();
+
+      const alphaIndex = result.indexOf('## alpha MCP Server Instructions');
+      const mangoIndex = result.indexOf('## mango MCP Server Instructions');
+      const zebraIndex = result.indexOf('## zebra MCP Server Instructions');
+
+      expect(alphaIndex).toBeGreaterThan(-1);
+      expect(mangoIndex).toBeGreaterThan(alphaIndex);
+      expect(zebraIndex).toBeGreaterThan(mangoIndex);
+    });
+
+    it('should sort filtered server instructions regardless of requested order', async () => {
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
+        zebra: {
+          type: 'stdio',
+          command: 'node',
+          args: ['zebra.js'],
+          serverInstructions: 'Zebra instructions',
+        },
+        alpha: {
+          type: 'stdio',
+          command: 'node',
+          args: ['alpha.js'],
+          serverInstructions: 'Alpha instructions',
+        },
+        mango: {
+          type: 'stdio',
+          command: 'node',
+          args: ['mango.js'],
+          serverInstructions: 'Mango instructions',
+        },
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const result = await manager.formatInstructionsForContext(['zebra', 'alpha']);
+
+      const alphaIndex = result.indexOf('## alpha MCP Server Instructions');
+      const zebraIndex = result.indexOf('## zebra MCP Server Instructions');
+
+      expect(alphaIndex).toBeGreaterThan(-1);
+      expect(zebraIndex).toBeGreaterThan(alphaIndex);
+      expect(result).not.toContain('mango');
+    });
+
     it('should return empty string when filtered servers have no instructions', async () => {
       (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         github: {


### PR DESCRIPTION
## Summary

Anthropic prompt caching invalidates whenever the prompt prefix changes. MCP server instructions and tool lists currently follow object-insertion / server-response order, which is not guaranteed to be stable across requests — silently breaking cache hits. This PR makes both deterministic (selective re-implementation of the intent of `feature/anthropic-cache-strategy`, the only part of that branch still unresolved on main).

## Changes

- `packages/api/src/mcp/MCPManager.ts`: sort MCP server instructions by server name (`localeCompare`) in `formatInstructionsForContext`.
- `api/app/clients/tools/util/handleTools.js`: sort `requestedMCPTools` by server name; sort tool configs within a server by tool key; sort the tool array returned by `createMCPTool(s)` by tool name (MCP `tools/list` response order is not guaranteed).

## Verification

- 5 new unit tests (2 in `MCPManager.test.ts`, 3 in `handleTools.test.js`), following existing test conventions.
- `packages/api` mcp suite: 43 suites / 1031 tests pass. `api` `handleTools.test.js`: 15 tests pass.
- eslint: no findings on the 4 changed files; `tsc --noEmit` (packages/api): clean.
- Codex self-review: 2 rounds — R1 Majors (within-server ordering gaps) fixed; R2 zero findings.

## Known limitation

Ordering uses default-locale `localeCompare`, so it can theoretically differ across hosts with different ICU configurations; within a single deployment it is stable, which satisfies the cache-key stabilization goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)